### PR TITLE
Fix broken new game

### DIFF
--- a/Content/FirstPerson/Blueprints/BP_FirstPersonGameMode.uasset
+++ b/Content/FirstPerson/Blueprints/BP_FirstPersonGameMode.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:73cd95021a63a698ff7a95ccc7d3d39824eb4c2aa6968b7353275a6b5d16c142
-size 58197
+oid sha256:870a7b1c2b6936ea0bed8d828e8d2ae0489d4e3ff4d468dfd01bc5af6ecd34e9
+size 69970

--- a/Content/FirstPerson/Blueprints/BP_FirstPersonGameMode.uasset
+++ b/Content/FirstPerson/Blueprints/BP_FirstPersonGameMode.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:870a7b1c2b6936ea0bed8d828e8d2ae0489d4e3ff4d468dfd01bc5af6ecd34e9
-size 69970
+oid sha256:fb43c6a0cd60a5d75bb33b8a0b5e25d050b573a0412a8b48ce96ab44a0ec97de
+size 58257

--- a/Content/Maps/MainMenuMap.umap
+++ b/Content/Maps/MainMenuMap.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6b57c0b1d7905996247dd80900d3e8fb6be75285303c40a2d685683fea49842a
+oid sha256:ee5e5355f34070ca019b0295dc82fa8e60360ce8b5cb97a9d3e3669f761ca995
 size 54399

--- a/Content/UI/FP_Controller.uasset
+++ b/Content/UI/FP_Controller.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:03dac3a2fe6f042e3dfe4d74d1fd8d3359bc857a3b0b9f7effc4ce9a08c448e1
-size 179082
+oid sha256:387259b28af207d84d01657fc785658b1956a1863b58c63817ceaf9de48cc05a
+size 195297

--- a/Content/UI/MainMenu/MenuGameMode.uasset
+++ b/Content/UI/MainMenu/MenuGameMode.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:10f77e3a644ffaff8bd967cb222a6d66a229baefa60e7538b14005fe8c2a7f04
-size 19217
+oid sha256:f39bb11fa57928697c5c43d5008bba0b480e463c2d673c7983bfc090c5530524
+size 19187

--- a/Source/CapstoneProject/Private/CPP_GameState.cpp
+++ b/Source/CapstoneProject/Private/CPP_GameState.cpp
@@ -2,6 +2,7 @@
 
 #include "CPP_GameState.h"
 #include "CPP_PlayerState.h"
+#include "GameFramework/GameMode.h"
 #include "Kismet/GameplayStatics.h"
 
 // Debug print, with quotations. E.g., `D("Hello World");` 
@@ -15,7 +16,7 @@
 ACPP_GameState::ACPP_GameState()
 {
 	this->mode = TEXT("time");
-	this->kills_to_end = 3;
+	this->kills_to_end = 1;
 	this->GameEndTimeInSeconds = 90.f;
 	this->bReplicates = true;
 }
@@ -38,7 +39,6 @@ void ACPP_GameState::ResetStateForNewGame()
 		FString DisplayMessage = WinnerName + " won the game with " + NumberOfKills + " kills!";
 
 		DFstr(DisplayMessage);
-		D("Resetting all player stats.");
 		GetWorld()->ServerTravel("/Game/Maps/BloodGulch/BloodGulch?listen", true);
 	}
 }

--- a/Source/CapstoneProject/Private/CPP_GameState.cpp
+++ b/Source/CapstoneProject/Private/CPP_GameState.cpp
@@ -16,7 +16,7 @@
 ACPP_GameState::ACPP_GameState()
 {
 	this->mode = TEXT("time");
-	this->kills_to_end = 1;
+	this->kills_to_end = 3;
 	this->GameEndTimeInSeconds = 90.f;
 	this->bReplicates = true;
 }
@@ -39,7 +39,7 @@ void ACPP_GameState::ResetStateForNewGame()
 		FString DisplayMessage = WinnerName + " won the game with " + NumberOfKills + " kills!";
 
 		DFstr(DisplayMessage);
-		GetWorld()->ServerTravel("/Game/Maps/BloodGulch/BloodGulch?listen", true);
+		GetWorld()->ServerTravel("?Restart", true);
 	}
 }
 


### PR DESCRIPTION
When transitioning bewteen games, there were cases where a player would be unable to control the new pawn. I didn't pinpoint exactly why this happened but I suspect it was related to the HUD's focus not being reset, which is now reset for every new player controller. Additionally, foundational work has been set up to experiment more with seamless traveling if the problem continues.