### PR TITLE
Remove lobbies option from joining and seracing games

### DIFF
--- a/Content/UI/MainMenu/WB_MainMenuScreen.uasset
+++ b/Content/UI/MainMenu/WB_MainMenuScreen.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6be436a98ae0387dac80b45158abb685023204f26f89f7a8bad3fa04d2b72965
-size 55744
+oid sha256:ddaf4362b1972640d3f57839a060618bffdf162510090bfd5b76a80f404cf2b7
+size 52879

--- a/Content/UI/MainMenu/sessions/WB_SessionList.uasset
+++ b/Content/UI/MainMenu/sessions/WB_SessionList.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:950835c78b36fc3428ddc8925af28cd80c27c8acf402d4941bebf9ffaf37f245
-size 51332
+oid sha256:0b5166fe89844cc7b6166b4444a61d038336a5078cb0c19866fede1c8933d872
+size 45527

--- a/Source/CapstoneProject/Private/MainMenuScreen.cpp
+++ b/Source/CapstoneProject/Private/MainMenuScreen.cpp
@@ -43,7 +43,7 @@ void UMainMenuScreen::OnClickCreateGameButton()
 	const FName ServerName = ServerNameEditableTextBox ? FName(ServerNameEditableTextBox->GetText().ToString()) : DEFAULT_SERVER_NAME;
 	bool bIsLan = LanCheckBox ? LanCheckBox->IsChecked() : true;
 	bool bUsesPresence = PresenceCheckBox ? PresenceCheckBox->IsChecked() : true;
-	bool bUseLobbies = UseLobbiesCheckBox ? UseLobbiesCheckBox->IsChecked() : false;
+	bool bUseLobbies = false;
 	const int32 MaxPlayers = 20;
 	SessionGameInstance->StartOnlineGame(ServerName, bIsLan, bUsesPresence, MaxPlayers, bUseLobbies);
 }
@@ -80,14 +80,6 @@ void UMainMenuScreen::SetUsePresence(bool bUsePresence)
 	if (PresenceCheckBox)
 	{
 		PresenceCheckBox->SetIsChecked(bUsePresence);
-	}
-}
-
-void UMainMenuScreen::SetUseLobbies(bool bUseLobbies)
-{
-	if (UseLobbiesCheckBox)
-	{
-		UseLobbiesCheckBox->SetIsChecked(bUseLobbies);
 	}
 }
 

--- a/Source/CapstoneProject/Private/SessionGameInstance.cpp
+++ b/Source/CapstoneProject/Private/SessionGameInstance.cpp
@@ -307,7 +307,7 @@ void USessionGameInstance::DestroySessionAndLeaveGame()
 void USessionGameInstance::PopulateWidgetWithOnlineGames(USessionList* SessionListWidget)
 {
 	MenuWidgetHandle = SessionListWidget; // update once finished
-	FindOnlineGames(SessionListWidget->LANCheckBox->IsChecked(), SessionListWidget->PresenceCheckBox->IsChecked(), SessionListWidget->SearchLobbiesCheckBox->IsChecked());
+	FindOnlineGames(SessionListWidget->LANCheckBox->IsChecked(), SessionListWidget->PresenceCheckBox->IsChecked(), false);
 }
 
 void USessionGameInstance::JoinOnlineGameProvidedSearchResult(FOnlineSessionSearchResult* SearchResult)

--- a/Source/CapstoneProject/Private/SessionList.cpp
+++ b/Source/CapstoneProject/Private/SessionList.cpp
@@ -68,14 +68,6 @@ void USessionList::SetUsePresence(bool bUsePresence)
 	}
 }
 
-void USessionList::SetSearchLobbies(bool bSearchLobbies)
-{
-	if (SearchLobbiesCheckBox)
-	{
-		SearchLobbiesCheckBox->SetIsChecked(bSearchLobbies);
-	}
-}
-
 void USessionList::AddSessionListing(USessionListing* SessionListing)
 {
 	if (SessionListingsScrollBox)

--- a/Source/CapstoneProject/Public/MainMenuScreen.h
+++ b/Source/CapstoneProject/Public/MainMenuScreen.h
@@ -21,9 +21,7 @@ protected:
 	void SetHostOnLan(bool bHostOnLAN);
 
 	void SetUsePresence(bool bUsePresence);
-
-	void SetUseLobbies(bool bUseLobbies);
-
+	
 	UFUNCTION()
 	void OnSessionNameTextChanged(const FText& Text);
 	
@@ -56,7 +54,4 @@ protected:
 
 	UPROPERTY(EditAnywhere, meta = (BindWidget))
 	UCheckBox* PresenceCheckBox;
-	
-	UPROPERTY(EditAnywhere, meta = (BindWidget))
-	UCheckBox* UseLobbiesCheckBox;
 };

--- a/Source/CapstoneProject/Public/SessionList.h
+++ b/Source/CapstoneProject/Public/SessionList.h
@@ -22,7 +22,6 @@ public:
 	
 	void ClearSessionListings();
 	void SetUsePresence(bool bUsePresence);
-	void SetSearchLobbies(bool bSearchLobbies);
 
 	USessionListing* USessionList::CreateAndInsertSessionListingWidget(FOnlineSessionSearchResult& SearchResult, FName SessionName);
 
@@ -40,9 +39,6 @@ public:
 
 	UPROPERTY(EditAnywhere, meta = (BindWidget))
 	UCheckBox* PresenceCheckBox;
-
-	UPROPERTY(EditAnywhere, meta = (BindWidget))
-	UCheckBox* SearchLobbiesCheckBox;
 
 	UPROPERTY(EditAnywhere, meta = (BindWidget))
 	UButton* RefreshButton;


### PR DESCRIPTION
When creating games with the UseLobbies flag set, an assertion failure would trigger when destroying a session, resulting in an unexpected crash. Because there are no use cases for Lobbies yet, I have removed the flag altogether